### PR TITLE
Update module.tf

### DIFF
--- a/module.tf
+++ b/module.tf
@@ -19,7 +19,6 @@ resource "azurerm_key_vault" "akv" {
   enabled_for_disk_encryption     = lookup(var.akv_config.akv_features, "enabled_for_disk_encryption", null)
   enabled_for_deployment          = lookup(var.akv_config.akv_features, "enabled_for_deployment", null)
   enabled_for_template_deployment = lookup(var.akv_config.akv_features, "enabled_for_template_deployment", null)
-  soft_delete_enabled             = lookup(var.akv_config.akv_features, "soft_delete_enabled", null)
   purge_protection_enabled        = lookup(var.akv_config.akv_features, "purge_protection_enabled", null)
 
   dynamic "network_acls" {


### PR DESCRIPTION
"soft_delete_enabled": [DEPRECATED] Azure has removed support for disabling Soft Delete as of 2020-12-15, as such this field is no longer configurable and can be safely removed. This field will be removed in version 3.0 of the Azure Provider.